### PR TITLE
Rewrite README with storytelling approach to highlight repository maintenance pain

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,27 @@
 # changes-roller
 
-A command-line tool for creating and managing coordinated patch series across multiple Git repositories simultaneously.
+**Stop manually patching dozens of repositories. Automate it.**
 
-## Overview
+**Changes-Roller** is a command-line tool for creating and managing coordinated
+patch series across multiple Git repositories simultaneously.
 
-changes-roller automates the workflow of applying consistent changes to many projects and optionally submitting them for code review. It's perfect for:
+## Why changes-roller?
 
+It's Tuesday morning, and you've just discovered a critical security vulnerability affecting 47 of your repositories. You know what comes next: hours of manual cloning, editing, committing, and reviewing. Your afternoon vanishes into mechanical `git clone`, `git commit`, `git review` while your actual development work waits.
+
+changes-roller transforms this soul-crushing routine into a five-minute automation. Write your patch script once, then watch as it executes across all repositories in parallel. What used to consume your entire afternoon now runs while you grab coffee—with consistent changes, uniform commit messages, and organized code reviews.
+
+**Perfect for:**
 - Security updates across multiple microservices
-- Dependency upgrades
-- API migrations
-- License header updates
-- Compliance fixes
+- Dependency upgrades throughout your service ecosystem
+- API migrations affecting client libraries
+- License header updates for compliance
+- Configuration file standardization
+- Any scenario requiring identical changes across multiple repositories
+
+## How It Works
+
+Configure once, execute everywhere. You provide the repositories to update and a script containing your changes. changes-roller handles everything else—cloning, patching, testing, committing, and submitting for review. Parallel execution means 50 repositories finish almost as quickly as one. Built-in error handling ensures you get clear feedback about any issues, while successful repositories continue processing.
 
 ## Features
 


### PR DESCRIPTION
Replace dry technical description with engaging narrative that helps readers feel the daily frustration of bulk repository patching. The new introduction walks through the real scenario of discovering a security vulnerability and facing hours of manual work across dozens of OpenStack repositories.

Changes emphasize the emotional and time cost of manual maintenance while showing how changes-roller transforms this from soul-crushing routine into automated precision. Added concrete scenarios section to help users quickly identify if the tool fits their needs.

This storytelling approach better conveys why changes-roller exists and the specific pain points it solves for OpenStack maintainers managing 100+ repos.